### PR TITLE
fix "automatically take arch with dpkg-architecture"

### DIFF
--- a/pkg/deb/blksnap-dev/build.sh
+++ b/pkg/deb/blksnap-dev/build.sh
@@ -8,9 +8,9 @@ else
 	VERSION="1.0.0.0"
 fi
 
-if [ -n `dpkg-architecture -q DEB_HOST_ARCH` ]
+if [ -n "$(dpkg-architecture -q DEB_HOST_ARCH)" ]
 then
-	ARCH=`dpkg-architecture -q DEB_HOST_ARCH`
+	ARCH="$(dpkg-architecture -q DEB_HOST_ARCH)"
 else
 	ARCH="amd64"
 fi

--- a/pkg/deb/blksnap-tests/build.sh
+++ b/pkg/deb/blksnap-tests/build.sh
@@ -7,9 +7,9 @@ then
 else
 	VERSION="1.0.0.0"
 fi
-if [ -n `dpkg-architecture -q DEB_HOST_ARCH` ]
+if [ -n "$(dpkg-architecture -q DEB_HOST_ARCH)" ]
 then
-	ARCH=`dpkg-architecture -q DEB_HOST_ARCH`
+	ARCH="$(dpkg-architecture -q DEB_HOST_ARCH)"
 else
 	ARCH="amd64"
 fi

--- a/pkg/deb/blksnap-tools/build.sh
+++ b/pkg/deb/blksnap-tools/build.sh
@@ -7,9 +7,9 @@ then
 else
 	VERSION="1.0.0.0"
 fi
-if [ -n `dpkg-architecture -q DEB_HOST_ARCH` ]
+if [ -n "$(dpkg-architecture -q DEB_HOST_ARCH)" ]
 then
-	ARCH=`dpkg-architecture -q DEB_HOST_ARCH`
+	ARCH="$(dpkg-architecture -q DEB_HOST_ARCH)"
 else
 	ARCH="amd64"
 fi


### PR DESCRIPTION
fix things spotted by codefactor:
- -n doesn't work with unquoted arguments. Quote or use [[ ]]
- Use $(...) notation instead of legacy backticks `...`